### PR TITLE
update: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ export default defineComponent({
     }
   }
 })
-</scirpt>
+</script>
 ```


### PR DESCRIPTION
Change `</scirpt>` to `</script>`